### PR TITLE
feat(gulp): add ng-annotate

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -14,6 +14,7 @@ stylus = require 'gulp-stylus'
 fs = require 'fs'
 path = require 'path'
 inject = require 'gulp-inject'
+ngAnnotate = require 'gulp-ng-annotate'
 ngtemplate = require 'gulp-ngtemplate'
 htmlmin = require 'gulp-htmlmin'
 
@@ -70,6 +71,7 @@ gulp.task 'compile_template', ['compile_coffee', 'clean'], ->
 gulp.task 'compile_coffee', ['clean'], ->
   gulp.src ['src/*/*.coffee', 'src/components.coffee']
     .pipe coffee({bare: true})
+    .pipe ngAnnotate({single_quotes: true})
     .pipe gulp.dest('.src-js')
 
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gulp-inject": "^1.2.0",
     "gulp-jade": "^1.0.0",
     "gulp-jsdoc-to-markdown": "^1.0.2",
+    "gulp-ng-annotate": "^0.5.2",
     "gulp-ngtemplate": "^0.2.3",
     "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^1.5.2",


### PR DESCRIPTION
Any objection to letting ng-annotate manage our dependency injection annotations?

You write this:

``` coffee
module.directive 'shiftSomeComponent', (
  $compile
  $filter
) ->
  # hax
```

And gulp will generating the min-safe notation:

``` js
module.directive('shiftSomeComponent', ['$compile', '$filter', function($compile, $filter){}]);
```
