### PR TITLE
Sortable namespace

### DIFF
--- a/src/sortable/example/sortable.coffee
+++ b/src/sortable/example/sortable.coffee
@@ -13,5 +13,8 @@ angular.module('examples', ['shift.components'])
       'Mexico City'
     ]
 
+    $scope.items_visited = ['Paris', 'Los Angeles']
+    $scope.items_to_visit = []
+
     $scope.onItemOrderChange = (elements) ->
       console.log 'change', elements

--- a/src/sortable/example/sortable.coffee
+++ b/src/sortable/example/sortable.coffee
@@ -16,5 +16,11 @@ angular.module('examples', ['shift.components'])
     $scope.items_visited = ['Paris', 'Los Angeles']
     $scope.items_to_visit = []
 
+    $scope.onItemAdded = (element) ->
+      console.log 'added', element
+
+    $scope.onItemRemoved = (element) ->
+      console.log 'removed', element
+
     $scope.onItemOrderChange = (elements) ->
       console.log 'change', elements

--- a/src/sortable/example/sortable.jade
+++ b/src/sortable/example/sortable.jade
@@ -38,7 +38,7 @@ div(ng-controller="SortableCtrl")
       shift-sortable-added = "onItemAdded(item)"
       shift-sortable-removed = "onItemRemoved(item)"
     )
-      .sortable-element(ng-repeat = "item in items track by $index") {{ item }}
+      .sortable-element(ng-repeat = "item in items") {{ item }}
 
   .panel.column
     h3 Visited
@@ -46,7 +46,7 @@ div(ng-controller="SortableCtrl")
       shift-sortable = "items_visited"
       shift-sortable-namespace = "item_bucket"
     )
-      .sortable-element(ng-repeat = "item in items_visited track by $index") {{ item }}
+      .sortable-element(ng-repeat = "item in items_visited") {{ item }}
 
   .panel.column
     h3 Planned
@@ -54,4 +54,4 @@ div(ng-controller="SortableCtrl")
       shift-sortable = "items_to_visit"
       shift-sortable-namespace = "item_bucket"
     )
-      .sortable-element(ng-repeat = "item in items_to_visit track by $index") {{ item }}
+      .sortable-element(ng-repeat = "item in items_to_visit") {{ item }}

--- a/src/sortable/example/sortable.jade
+++ b/src/sortable/example/sortable.jade
@@ -35,7 +35,8 @@ div(ng-controller="SortableCtrl")
     .sortable-container(
       shift-sortable = "items"
       shift-sortable-namespace = "item_bucket"
-      shift-sortable-change = "onItemOrderChange(items)"
+      shift-sortable-added = "onItemAdded(item)"
+      shift-sortable-removed = "onItemRemoved(item)"
     )
       .sortable-element(ng-repeat = "item in items track by $index") {{ item }}
 
@@ -44,7 +45,6 @@ div(ng-controller="SortableCtrl")
     .sortable-container(
       shift-sortable = "items_visited"
       shift-sortable-namespace = "item_bucket"
-      shift-sortable-change = "onItemOrderChange(items_visited)"
     )
       .sortable-element(ng-repeat = "item in items_visited track by $index") {{ item }}
 
@@ -53,6 +53,5 @@ div(ng-controller="SortableCtrl")
     .sortable-container(
       shift-sortable = "items_to_visit"
       shift-sortable-namespace = "item_bucket"
-      shift-sortable-change = "onItemOrderChange(items_to_visit)"
     )
       .sortable-element(ng-repeat = "item in items_to_visit track by $index") {{ item }}

--- a/src/sortable/example/sortable.jade
+++ b/src/sortable/example/sortable.jade
@@ -27,3 +27,32 @@ div(ng-controller="SortableCtrl")
     span.sortable-element(ng-repeat = "item in items")
       i.fa.fa-align-justify
       |  {{ item }}
+
+  h2 Drag n Drop accross different list
+
+  .panel.column
+    h3 Cities
+    .sortable-container(
+      shift-sortable = "items"
+      shift-sortable-namespace = "item_bucket"
+      shift-sortable-change = "onItemOrderChange(items)"
+    )
+      .sortable-element(ng-repeat = "item in items track by $index") {{ item }}
+
+  .panel.column
+    h3 Visited
+    .sortable-container(
+      shift-sortable = "items_visited"
+      shift-sortable-namespace = "item_bucket"
+      shift-sortable-change = "onItemOrderChange(items_visited)"
+    )
+      .sortable-element(ng-repeat = "item in items_visited track by $index") {{ item }}
+
+  .panel.column
+    h3 Planned
+    .sortable-container(
+      shift-sortable = "items_to_visit"
+      shift-sortable-namespace = "item_bucket"
+      shift-sortable-change = "onItemOrderChange(items_to_visit)"
+    )
+      .sortable-element(ng-repeat = "item in items_to_visit track by $index") {{ item }}

--- a/src/sortable/example/sortable.jade
+++ b/src/sortable/example/sortable.jade
@@ -7,8 +7,11 @@ div(ng-controller="SortableCtrl")
 
   h2 Scope
 
-  code.code
-    | $scope.items = {{items}}
+  pre
+    code.code
+      | $scope.items = {{items}}
+      | $scope.items_visited = {{items_visited}}
+      | $scope.items_to_visit = {{items_to_visit}}
 
   h2 Drag n Drop
 
@@ -35,8 +38,8 @@ div(ng-controller="SortableCtrl")
     .sortable-container(
       shift-sortable = "items"
       shift-sortable-namespace = "item_bucket"
-      shift-sortable-added = "onItemAdded(item)"
-      shift-sortable-removed = "onItemRemoved(item)"
+      shift-sortable-add = "onItemAdded(item)"
+      shift-sortable-remove = "onItemRemoved(item)"
     )
       .sortable-element(ng-repeat = "item in items") {{ item }}
 

--- a/src/sortable/example/sortable.styl
+++ b/src/sortable/example/sortable.styl
@@ -1,7 +1,20 @@
 .sortable-container{
   position: relative;
   width: 400px;
+
 }
+
+.column{
+  width: 250px;
+  display: inline-block;
+  margin: 10px;
+  vertical-align: top;
+  .sortable-container{
+    width: auto;
+    min-height: 40px;
+  }
+}
+
 
 .sortable-element{
   background: #999;
@@ -26,3 +39,4 @@
   display: inline-block;
   vertical-align: middle;
 }
+

--- a/src/sortable/readme.md
+++ b/src/sortable/readme.md
@@ -7,6 +7,8 @@ Sortable directive to allow drag n' drop sorting of an array.
 | --- | --- | --- |
 | shiftSortable | <code>array</code> | Array of sortable object |
 | shiftSortableChange | <code>function</code> | Called when order is changed |
+| shiftSortableAdded | <code>function</code> | Called when an item gets added with the added item as argument |
+| shiftSortableRemoved | <code>function</code> | Called when an item gets removed with the removed item as argument |
 | shiftSortableHandle | <code>string</code> | CSS selector to grab the element (optional) |
 | shiftSortableNamespace | <code>string</code> | Namespace for to define multiple possible source and destinations. |
 

--- a/src/sortable/readme.md
+++ b/src/sortable/readme.md
@@ -7,8 +7,8 @@ Sortable directive to allow drag n' drop sorting of an array.
 | --- | --- | --- |
 | shiftSortable | <code>array</code> | Array of sortable object |
 | shiftSortableChange | <code>function</code> | Called when order is changed |
-| shiftSortableAdded | <code>function</code> | Called when an item gets added with the added item as argument |
-| shiftSortableRemoved | <code>function</code> | Called when an item gets removed with the removed item as argument |
+| shiftSortableAdd | <code>function</code> | Called when an item gets added with the added item as argument (`item` keyword is mandatory) |
+| shiftSortableRemove | <code>function</code> | Called when an item gets removed with the removed item as argument (`item` keyword is mandatory) |
 | shiftSortableHandle | <code>string</code> | CSS selector to grab the element (optional) |
 | shiftSortableNamespace | <code>string</code> | Namespace for to define multiple possible source and destinations. |
 
@@ -24,7 +24,8 @@ ul(
 
 ul(
   shift-sortable = "list_of_object_excluded"
-  shift-sortable-change = "onListOrderChange(list_of_object_excluded)"
+  shift-sortable-add = "onListAdd(item)"
+  shift-sortable-remove = "onListRemove(item)"
   shift-sortable-handle = ".grab-icon"
   shift-sortable-namespace = "bucket_list"
 )

--- a/src/sortable/readme.md
+++ b/src/sortable/readme.md
@@ -8,6 +8,7 @@ Sortable directive to allow drag n' drop sorting of an array.
 | shiftSortable | <code>array</code> | Array of sortable object |
 | shiftSortableChange | <code>function</code> | Called when order is changed |
 | shiftSortableHandle | <code>string</code> | CSS selector to grab the element (optional) |
+| shiftSortableNamespace | <code>string</code> | Namespace for to define multiple possible source and destinations. |
 
 **Example**  
 ```jade
@@ -15,6 +16,15 @@ ul(
   shift-sortable = "list_of_object"
   shift-sortable-change = "onListOrderChange(list_of_object)"
   shift-sortable-handle = ".grab-icon"
+  shift-sortable-namespace = "bucket_list"
 )
   li(ng-repeat = "element in list_of_object") {{ element.name }}
+
+ul(
+  shift-sortable = "list_of_object_excluded"
+  shift-sortable-change = "onListOrderChange(list_of_object_excluded)"
+  shift-sortable-handle = ".grab-icon"
+  shift-sortable-namespace = "bucket_list"
+)
+  li(ng-repeat = "element in list_of_object_excluded") {{ element.name }}
 ```

--- a/src/sortable/sortable.coffee
+++ b/src/sortable/sortable.coffee
@@ -8,10 +8,10 @@ Sortable directive to allow drag n' drop sorting of an array.
 
 @param {array} shiftSortable Array of sortable object
 @param {function} shiftSortableChange Called when order is changed
-@param {function} shiftSortableAdded Called when an item gets added with
-the added item as argument
-@param {function} shiftSortableRemoved Called when an item gets removed with
-the removed item as argument
+@param {function} shiftSortableAdd Called when an item gets added with
+the added item as argument (`item` keyword is mandatory)
+@param {function} shiftSortableRemove Called when an item gets removed with
+the removed item as argument (`item` keyword is mandatory)
 @param {string} shiftSortableHandle CSS selector to grab the element (optional)
 @param {string} shiftSortableNamespace Namespace for to define multiple possible
 source and destinations.
@@ -28,7 +28,8 @@ ul(
 
 ul(
   shift-sortable = "list_of_object_excluded"
-  shift-sortable-change = "onListOrderChange(list_of_object_excluded)"
+  shift-sortable-add = "onListAdd(item)"
+  shift-sortable-remove = "onListRemove(item)"
   shift-sortable-handle = ".grab-icon"
   shift-sortable-namespace = "bucket_list"
 )
@@ -52,8 +53,8 @@ angular.module 'shift.components.sortable', []
     scope:
       shiftSortable: '='
       shiftSortableChange: '&'
-      shiftSortableAdded: '&'
-      shiftSortableRemoved: '&'
+      shiftSortableAdd: '&'
+      shiftSortableRemove: '&'
       shiftSortableHandle: '@'
       shiftSortableNamespace: '@'
     link: (scope, element, attrs) ->
@@ -204,14 +205,14 @@ angular.module 'shift.components.sortable', []
           scope.$apply ->
             record = scope.shiftSortable.splice(start_position, 1)[0]
             scope.shiftSortableChange()
-            scope.shiftSortableRemoved({item:record})
+            scope.shiftSortableRemove({item:record})
 
           for sortable in sortables
             if sortable.container is drop_container
               sortable.scope.$apply ->
                 sortable.scope.shiftSortable.splice(end_position, 0, record)
                 sortable.scope.shiftSortableChange()
-                sortable.scope.shiftSortableAdded({item:record})
+                sortable.scope.shiftSortableAdd({item:record})
 
         # now that everything is back in place in the dom, trigger a digest
         else if position_changed

--- a/src/sortable/sortable.coffee
+++ b/src/sortable/sortable.coffee
@@ -8,6 +8,10 @@ Sortable directive to allow drag n' drop sorting of an array.
 
 @param {array} shiftSortable Array of sortable object
 @param {function} shiftSortableChange Called when order is changed
+@param {function} shiftSortableAdded Called when an item gets added with
+the added item as argument
+@param {function} shiftSortableRemoved Called when an item gets removed with
+the removed item as argument
 @param {string} shiftSortableHandle CSS selector to grab the element (optional)
 @param {string} shiftSortableNamespace Namespace for to define multiple possible
 source and destinations.
@@ -48,6 +52,8 @@ angular.module 'shift.components.sortable', []
     scope:
       shiftSortable: '='
       shiftSortableChange: '&'
+      shiftSortableAdded: '&'
+      shiftSortableRemoved: '&'
       shiftSortableHandle: '@'
       shiftSortableNamespace: '@'
     link: (scope, element, attrs) ->
@@ -198,12 +204,14 @@ angular.module 'shift.components.sortable', []
           scope.$apply ->
             record = scope.shiftSortable.splice(start_position, 1)[0]
             scope.shiftSortableChange()
+            scope.shiftSortableRemoved({item:record})
 
           for sortable in sortables
             if sortable.container is drop_container
               sortable.scope.$apply ->
                 sortable.scope.shiftSortable.splice(end_position, 0, record)
                 sortable.scope.shiftSortableChange()
+                sortable.scope.shiftSortableAdded({item:record})
 
         # now that everything is back in place in the dom, trigger a digest
         else if position_changed

--- a/src/sortable/sortable.coffee
+++ b/src/sortable/sortable.coffee
@@ -48,7 +48,7 @@ angular.module 'shift.components.sortable', []
 
       return namespaces[namespace]
 
-  .directive 'shiftSortable', ($timeout, shiftSortableService) ->
+  .directive 'shiftSortable', (shiftSortableService) ->
     restrict: 'A'
     scope:
       shiftSortable: '='

--- a/src/sortable/sortable.coffee
+++ b/src/sortable/sortable.coffee
@@ -231,7 +231,7 @@ angular.module 'shift.components.sortable', []
         # Prevent memory leakage
         container.removeEventListener 'mousedown', grab
 
-        if sortables:
+        if sortables
           # Deregister itself when destroyed
           _.remove sortables, (sortable) ->
             return sortable.scope is scope

--- a/src/sortable/sortable.coffee
+++ b/src/sortable/sortable.coffee
@@ -9,6 +9,8 @@ Sortable directive to allow drag n' drop sorting of an array.
 @param {array} shiftSortable Array of sortable object
 @param {function} shiftSortableChange Called when order is changed
 @param {string} shiftSortableHandle CSS selector to grab the element (optional)
+@param {string} shiftSortableNamespace Namespace for to define multiple possible
+source and destinations.
 
 @example
 ```jade
@@ -16,8 +18,17 @@ ul(
   shift-sortable = "list_of_object"
   shift-sortable-change = "onListOrderChange(list_of_object)"
   shift-sortable-handle = ".grab-icon"
+  shift-sortable-namespace = "bucket_list"
 )
   li(ng-repeat = "element in list_of_object") {{ element.name }}
+
+ul(
+  shift-sortable = "list_of_object_excluded"
+  shift-sortable-change = "onListOrderChange(list_of_object_excluded)"
+  shift-sortable-handle = ".grab-icon"
+  shift-sortable-namespace = "bucket_list"
+)
+  li(ng-repeat = "element in list_of_object_excluded") {{ element.name }}
 ```
 ###
 angular.module 'shift.components.sortable', []


### PR DESCRIPTION
This feature adds the possibility to move items from and to different lists. 

To allow a list to exchange item with another, you only need to define them on the same namespace:

```jade
h3 Wont visit
.sortable-container(
  shift-sortable = "bad_cities"
  shift-sortable-namespace = "ns_cities"
  shift-sortable-remove = "removed(item)" # item keyword is mandatory
  shift-sortable-add = "added(item)" # item keyword is mandatory
)
  .sortable-element(ng-repeat = "city in bad_cities") {{ city }}

h3 Visited
.sortable-container(
  shift-sortable = "cities_visited"
  shift-sortable-namespace = "ns_cities"
)
  .sortable-element(ng-repeat = "city in cities_visited") {{ city }}

h3 Planned
.sortable-container(
  shift-sortable = "cities_to_visit"
  shift-sortable-namespace = "ns_cities"
)
  .sortable-element(ng-repeat = "city in cities_to_visit") {{ city }}
```

![namespace](https://cloud.githubusercontent.com/assets/56964/7558730/d5898eca-f75f-11e4-998e-d63eda28639e.png)
